### PR TITLE
fix: SOAP envelope operator-precedence bug causing no more communication (#338)

### DIFF
--- a/main.js
+++ b/main.js
@@ -2101,14 +2101,13 @@ function createMessage(sType, aName, _ip, _port, cURL, body, actionID, cb) {
 					}
 
 					try {
-						const envelope =
-							result['s:Envelope'] || result['SOAP-ENV:Envelope'] || result['Envelope'] || result['Body']
-								? result
-								: null;
+						const soapEnvelope =
+							result['s:Envelope'] || result['SOAP-ENV:Envelope'] || result['Envelope'] || null;
+						const envelope = soapEnvelope || result;
 						const body = result['Body']
 							? result['Body']
-							: envelope
-								? envelope['s:Body'] || envelope['SOAP-ENV:Body'] || envelope['Body']
+							: soapEnvelope
+								? soapEnvelope['s:Body'] || soapEnvelope['SOAP-ENV:Body'] || soapEnvelope['Body']
 								: null;
 						const response = body ? (Array.isArray(body) ? body[0] : body) : null;
 

--- a/main.js
+++ b/main.js
@@ -2103,7 +2103,6 @@ function createMessage(sType, aName, _ip, _port, cURL, body, actionID, cb) {
 					try {
 						const soapEnvelope =
 							result['s:Envelope'] || result['SOAP-ENV:Envelope'] || result['Envelope'] || null;
-						const envelope = soapEnvelope || result;
 						const body = result['Body']
 							? result['Body']
 							: soapEnvelope


### PR DESCRIPTION
## Problem

Fixes #338 — "No more communication" regression seit v1.1.1.

## Root Cause

Operator-Precedence-Bug in `createMessage()` (`main.js`). Der Ternary-Operator hat niedrigere Precedence als `||`, sodass `envelope` immer das gesamte `result`-Objekt war statt `result['s:Envelope']`. Dadurch war `envelope['s:Body']` immer `undefined`, `response = null`, keine State-Updates.

## Fix

Separate `soapEnvelope`-Variable extrahieren (null wenn nicht vorhanden), dann `envelope = soapEnvelope || result`. Body-Lookup nutzt `soapEnvelope` direkt.

## Warum v1.1.0 funktioniert hat

v1.1.0 nutzte `request` + `xml2js` direkt — flachere Struktur die der alte Code korrekt traversiert hat. Mit `fast-xml-parser` + Namespace-Prefixes hat dieser latente Bug zugeschlagen.